### PR TITLE
Email and compact banner

### DIFF
--- a/action/banner.php
+++ b/action/banner.php
@@ -12,6 +12,9 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
     /** @var \helper_plugin_structpublish_db */
     protected $dbHelper;
 
+    /** @var bool */
+    protected $compactView;
+
     /** @inheritDoc */
     public function register(Doku_Event_Handler $controller)
     {
@@ -37,6 +40,8 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
             return;
         }
 
+        $this->compactView = (bool)$this->getConf('compact_view');
+
         // get the possible revisions needed in the banner
         $newestRevision = new Revision($this->dbHelper->getDB(), $ID, $INFO['currentrev']);
         if ($REV) {
@@ -47,7 +52,8 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
         $latestpubRevision = $newestRevision->getLatestPublishedRevision();
         $prevpubRevision = $shownRevision->getLatestPublishedRevision($REV ?:  $INFO['currentrev']);
 
-        $banner = '<div class="plugin-structpublish-banner ' . $shownRevision->getStatus() . '">';
+        $compactClass = $this->compactView ? ' compact' : '';
+        $banner = '<div class="plugin-structpublish-banner ' . $shownRevision->getStatus() . $compactClass . '">';
 
         // status of the shown revision
         $banner .= '<span class="icon">' .
@@ -103,7 +109,8 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
             '{version}' => hsc($rev->getVersion()),
         ];
 
-        $text = $this->getLang("banner_$name");
+        $text = $this->getLang($this->compactView ? "compact_banner_$name" : "banner_$name");
+
         $text = strtr($text, $replace);
 
         // add link to diff view
@@ -113,7 +120,9 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
             $text .= ' <a href="' . $link . '" title="' . $this->getLang('diff') . '">' . $icon . '</a>';
         }
 
-        return "<p class='$name'>$text</p>";
+        $tag = $this->compactView ? 'span' : 'p';
+
+        return "<$tag class='$name'>$text</$tag>";
     }
 
     /**

--- a/action/publish.php
+++ b/action/publish.php
@@ -15,6 +15,7 @@ class action_plugin_structpublish_publish extends DokuWiki_Action_Plugin
      *
      * @param Doku_Event $event
      * @return void
+     * @throws Exception
      */
     public function changeStatus(Doku_Event $event)
     {
@@ -23,14 +24,21 @@ class action_plugin_structpublish_publish extends DokuWiki_Action_Plugin
         }
 
         global $INPUT;
+
         $in = $INPUT->arr('structpublish');
-        if (!$in || !in_array(key($in), [Constants::ACTION_PUBLISH, Constants::ACTION_APPROVE])) {
+        $action = key($in);
+        if (!$action || !in_array($action, [Constants::ACTION_PUBLISH, Constants::ACTION_APPROVE])) {
             return;
         }
 
         if (!checkSecurityToken()) return;
 
+        /** @var helper_plugin_structpublish_publish $helper */
         $helper = plugin_load('helper', 'structpublish_publish');
-        $helper->saveRevision(key($in), $INPUT->str('version'));
+        $newRevision = $helper->saveRevision(key($in), $INPUT->str('version'));
+
+        /** @var helper_plugin_structpublish_notify $notifyHelper */
+        $notifyHelper  = plugin_load('helper', 'structpublish_notify');
+        $notifyHelper->sendEmails($action, $newRevision);
     }
 }

--- a/conf/default.php
+++ b/conf/default.php
@@ -6,3 +6,5 @@
  */
 
 $conf['restrict_admin'] = 1;
+$conf['email_enable'] = 0;
+$conf['email_status'] = '';

--- a/conf/default.php
+++ b/conf/default.php
@@ -8,3 +8,4 @@
 $conf['restrict_admin'] = 1;
 $conf['email_enable'] = 0;
 $conf['email_status'] = '';
+$conf['compact_view'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,3 +8,4 @@
 $meta['restrict_admin'] = ['onoff'];
 $meta['email_enable'] = ['onoff'];
 $meta['email_status'] = ['multicheckbox', '_other' => 'never', '_choices' => ['approve', 'publish']];
+$meta['compact_view'] = ['onoff'];

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -6,3 +6,5 @@
  */
 
 $meta['restrict_admin'] = ['onoff'];
+$meta['email_enable'] = ['onoff'];
+$meta['email_status'] = ['multicheckbox', '_other' => 'never', '_choices' => ['approve', 'publish']];

--- a/helper/notify.php
+++ b/helper/notify.php
@@ -1,0 +1,173 @@
+<?php
+
+use dokuwiki\Extension\AuthPlugin;
+use dokuwiki\plugin\structpublish\meta\Assignments;
+use dokuwiki\plugin\structpublish\meta\Constants;
+use dokuwiki\plugin\structpublish\meta\Revision;
+
+/**
+ * Notification helper
+ */
+class helper_plugin_structpublish_notify extends DokuWiki_Plugin
+{
+    /** @var helper_plugin_structpublish_db  */
+    protected $dbHelper;
+
+    public function __construct()
+    {
+        $this->dbHelper = plugin_load('helper', 'structpublish_db');
+    }
+
+    /**
+     * If activated, send emails on configured status changes.
+     *
+     * @param string $action
+     * @param Revision $newRevision
+     * @return void
+     * @throws Exception
+     */
+    public function sendEmails($action, $newRevision)
+    {
+
+        if (!$this->triggerNotification($action)) return;
+
+        // get assignees from DB
+        $assignments = Assignments::getInstance();
+        $assignees = $assignments->getPageAssignments($newRevision->getId(), false);
+
+        // get recipients for the next workflow step
+        $nextAction = Constants::workflowSteps($action)['nextAction'];
+        if (is_null($nextAction)) return;
+
+        if (empty($assignees[$nextAction])) {
+            msg($this->getLang('email_error_norecipients'), -1);
+            return;
+        }
+
+        // flatten the array and split into single user or group items
+        $assignees = implode(',', array_values($assignees[$nextAction]));
+        $assignees = explode(',', $assignees);
+
+        // get recipient emails
+        $recipients = $this->resolveRecipients($assignees);
+
+        // prepare mail text
+        $mailText = $this->prepareMailText($newRevision->getStatus());
+
+        $this->sendMail(implode(',', $recipients), $mailText);
+    }
+
+    /**
+     * @param string $recipients Comma separated list of emails
+     * @param string $mailText
+     * @return void
+     */
+    public function sendMail($recipients, $mailText)
+    {
+        $mailer = new Mailer();
+        $mailer->bcc($recipients);
+
+        $subject = $this->getLang('email_subject');
+        $mailer->subject($subject);
+
+        $mailer->setBody($mailText);
+        $mailer->send();
+    }
+
+    /**
+     * Processes an array of (comma separated) recipients
+     * and returns an array of emails
+     * with user groups resolved to individual users
+     *
+     * @param array $recipients
+     * @return array
+     * @throws Exception
+     */
+    public function resolveRecipients($recipients)
+    {
+        $resolved = [];
+
+        $recipients = array_unique($recipients);
+
+        foreach ($recipients as $recipient) {
+            $recipient = trim($recipient);
+
+            if ($recipient[0] === '@') {
+                $this->resolveGroup($resolved, $recipient);
+            } elseif (strpos($recipient, '@') === false) {
+                $this->resolveUser($resolved, $recipient);
+            } else {
+                $resolved[] = $recipient;
+            }
+        }
+        return $resolved;
+    }
+
+    /**
+     * @param array $resolved
+     * @param string $recipient
+     * @return void
+     * @throws Exception
+     */
+    protected function resolveGroup(&$resolved, $recipient)
+    {
+        /** @var AuthPlugin $auth */
+        global $auth;
+        if (!$auth->canDo('getUsers')) {
+            throw new \Exception('Auth cannot fetch users by group.');
+        }
+
+        $users = $auth->retrieveUsers(0, 0, ['grps' => substr($recipient, 1)]);
+        foreach ($users as $user) {
+            $resolved[] = $user['mail'];
+        }
+    }
+
+    /**
+     * @param array $resolved
+     * @param string $recipient
+     * @return void
+     */
+    protected function resolveUser(&$resolved, $recipient)
+    {
+        /** @var AuthPlugin $auth */
+        global $auth;
+        $user = $auth->getUserData($recipient);
+        if ($user) $resolved[] = $user['mail'];
+    }
+
+    /**
+     * Check configuration to see if a notification should be triggered.
+     *
+     * @return bool
+     */
+    private function triggerNotification($action)
+    {
+        if (!$this->getConf('email_enable')) return false;
+
+        $actions = array_map('trim', explode(',', $this->getConf('email_status')));
+        return in_array($action, $actions);
+    }
+
+    /**
+     * @return string
+     */
+    protected function prepareMailText($status)
+    {
+        global $ID;
+
+        $mailtext = file_get_contents($this->localFN('mail'));
+
+        $vars = [
+            'PAGE' => $ID,
+            'URL' => wl($ID, '', true),
+            'STATUS_CURRENT' => $status,
+        ];
+
+        foreach ($vars as $var => $val) {
+            $mailtext = str_replace('@' . $var . '@', $val, $mailtext);
+        }
+
+        return $mailtext;
+    }
+}

--- a/helper/publish.php
+++ b/helper/publish.php
@@ -25,7 +25,7 @@ class helper_plugin_structpublish_publish extends DokuWiki_Plugin
      * Save publish data
      *
      * @param string $action
-     * @return void
+     * @return Revision
      * @throws Exception
      */
     public function saveRevision($action, $newversion = '')
@@ -53,6 +53,8 @@ class helper_plugin_structpublish_publish extends DokuWiki_Plugin
         if ($action === Constants::ACTION_PUBLISH) {
             $this->updateSchemaData();
         }
+
+        return $revision;
     }
 
     /**

--- a/lang/de/mail.txt
+++ b/lang/de/mail.txt
@@ -1,0 +1,5 @@
+Hallo,
+
+Status der Seite  “@PAGE@” wurde geändert zu @STATUS_CURRENT@.
+
+Sie können hier die aktuelle Revision bearbeiten: @URL@

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -3,3 +3,4 @@
 $lang['restrict_admin'] = 'Regeln gelten auch für Superusers. Wenn deaktiviert, Admins dürfen nicht freigegebe Revisionen sehen, auch wenn sie keine Freigabeberechtigungen haben.';
 $lang['email_enable'] = 'E-Mails aktivieren';
 $lang['email_status'] = 'Bei welchen Statusänderungen sollen E-Mails versendet werden?';
+$lang['compact_view'] = 'Kompakter Banner';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -1,3 +1,5 @@
 <?php
 
 $lang['restrict_admin'] = 'Regeln gelten auch für Superusers. Wenn deaktiviert, Admins dürfen nicht freigegebe Revisionen sehen, auch wenn sie keine Freigabeberechtigungen haben.';
+$lang['email_enable'] = 'E-Mails aktivieren';
+$lang['email_status'] = 'Bei welchen Statusänderungen sollen E-Mails versendet werden?';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -34,3 +34,6 @@ $lang['assign_status'] = 'Status';
 $lang['assign_add'] = 'Add assignment';
 $lang['assign_del'] = 'Remove assignment';
 
+// email
+$lang['email_subject'] = 'Publish status of a wiki page has changed';
+$lang['email_error_norecipients'] = 'No recipients found to notify!';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -26,6 +26,12 @@ $lang['banner_status_published'] = 'This page revision has been <strong>publishe
 $lang['banner_latest_publish'] = 'The page was most recently published as version {version} by {user} on {datetime}.';
 $lang['banner_previous_publish'] = 'The page was previously published as version {version} by {user} on {datetime}.';
 $lang['banner_latest_draft'] = 'A newer working draft created on {revision} exists.';
+$lang['compact_banner_status_draft'] = 'Draft';
+$lang['compact_banner_status_approved'] = 'Approved';
+$lang['compact_banner_status_published'] = 'Published as version "{version}"';
+$lang['compact_banner_latest_publish'] = '';
+$lang['compact_banner_previous_publish'] = '';
+$lang['compact_banner_latest_draft'] = 'Newer draft: {revision}';
 
 // admin
 $lang['assign_pattern'] = 'Pattern';

--- a/lang/en/mail.txt
+++ b/lang/en/mail.txt
@@ -1,0 +1,5 @@
+Hello,
+
+This is to notify you that the status of the page “@PAGE@” has changed to @STATUS_CURRENT@.
+
+You may want to take action here: @URL@

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,5 @@
 <?php
 
 $lang['restrict_admin'] = 'Publishing rules apply to superusers too. Uncheck if admins should see unpublished revisions even if they are not publishers.';
+$lang['email_enable'] = 'Send emails';
+$lang['email_status'] = 'Status changes that trigger emails';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -3,3 +3,4 @@
 $lang['restrict_admin'] = 'Publishing rules apply to superusers too. Uncheck if admins should see unpublished revisions even if they are not publishers.';
 $lang['email_enable'] = 'Send emails';
 $lang['email_status'] = 'Status changes that trigger emails';
+$lang['compact_view'] = 'Compact banner';

--- a/meta/Constants.php
+++ b/meta/Constants.php
@@ -34,4 +34,26 @@ class Constants
 
         return $map[$action];
     }
+
+    public static function workflowSteps($action)
+    {
+        $map = [
+            self::ACTION_APPROVE => [
+                'fromStatus' => self::STATUS_DRAFT,
+                'currentStatus' => self::STATUS_APPROVED,
+                'toStatus' => self::STATUS_PUBLISHED,
+                'previousAction' => null,
+                'nextAction' => self::ACTION_PUBLISH
+            ],
+            self::ACTION_PUBLISH => [
+                'fromStatus' => self::STATUS_APPROVED,
+                'currentStatus' => self::STATUS_PUBLISHED,
+                'toStatus' => null,
+                'previousAction' => self::ACTION_APPROVE,
+                'nextAction' => null
+            ],
+        ];
+
+        return $map[$action];
+    }
 }

--- a/style.less
+++ b/style.less
@@ -1,9 +1,12 @@
 .plugin-structpublish-banner {
 
     border: 1px solid @ini_background_alt;
-    padding: 1rem;
-    margin-bottom: 1.5rem;
     background-color: @ini_background_alt;
+
+    &:not(.compact) {
+        padding: 1rem;
+        margin-bottom: 1.5rem;
+    }
 
     .icon svg {
         float: left;
@@ -40,6 +43,26 @@
         }
     }
 
+    &.compact {
+        padding: 0.2rem 0 0.2rem 0;
+
+        span.icon svg {
+            width: 2rem;
+            height: 1.5rem;
+        }
+
+        form {
+            float: right;
+
+            label {
+                margin-left: 1rem;
+            }
+
+            input {
+                width: 4rem;
+            }
+        }
+    }
 }
 
 .plugin-structpublish-version {


### PR DESCRIPTION
This PR introduces email notifications and two other small changes.

1. Emails are deactivated per default and can be separately activated for each workflow step.
2. Suppression of "old revision" message when a regular user views the latest published revision and has no permissions for the subsequent draft.
3. A configuration setting to change banner view to compact
<img width="702" alt="draft" src="https://github.com/cosmocode/dokuwiki-plugin-structpublish/assets/17853330/99d497a9-e1a3-438d-8dd6-d36d04225608">

<img width="701" alt="approved" src="https://github.com/cosmocode/dokuwiki-plugin-structpublish/assets/17853330/af8e339a-2a6b-48ae-b6c3-c2524e8e289b">

<img width="696" alt="published" src="https://github.com/cosmocode/dokuwiki-plugin-structpublish/assets/17853330/4e918cb4-8f3f-4912-b7cc-2347b12b5288">