### PR TITLE
Fix isPublisher() check

### DIFF
--- a/action/cache.php
+++ b/action/cache.php
@@ -3,6 +3,7 @@
 /**
  * Double caching of pages containing struct aggregations:
  * one for regular users, one for publishers/approvers
+ *
  * @see action_plugin_struct_cache
  */
 class action_plugin_structpublish_cache extends DokuWiki_Action_Plugin

--- a/action/migration.php
+++ b/action/migration.php
@@ -42,7 +42,9 @@ class action_plugin_structpublish_migration extends DokuWiki_Action_Plugin
 
         // check if struct has required version
         if ($dbVersionStruct < self::MIN_DB_STRUCT) {
-            throw new Exception('Plugin struct is outdated. Minimum required database version is ' . self::MIN_DB_STRUCT);
+            throw new Exception(
+                'Plugin struct is outdated. Minimum required database version is ' . self::MIN_DB_STRUCT
+            );
         }
 
         // check whether we are already up-to-date

--- a/action/revisions.php
+++ b/action/revisions.php
@@ -1,11 +1,10 @@
 <?php
 
 use dokuwiki\plugin\structpublish\meta\Revision;
-use \dokuwiki\plugin\structpublish\meta\Constants;
+use dokuwiki\plugin\structpublish\meta\Constants;
 
 class action_plugin_structpublish_revisions extends DokuWiki_Action_Plugin
 {
-
     public function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('FORM_REVISIONS_OUTPUT', 'BEFORE', $this, 'handleRevisions');
@@ -27,7 +26,9 @@ class action_plugin_structpublish_revisions extends DokuWiki_Action_Plugin
         /** @var helper_plugin_structpublish_db $helper */
         $helper = plugin_load('helper', 'structpublish_db');
 
-        if (!$helper->isPublishable()) return;
+        if (!$helper->isPublishable()) {
+            return;
+        }
 
         $elCount = $form->elementCount();
         $checkName = 'rev2[]';
@@ -52,9 +53,14 @@ class action_plugin_structpublish_revisions extends DokuWiki_Action_Plugin
             $version = $revision->getVersion();
 
             // insert status for published revisions
-            if (is_a($el, \dokuwiki\Form\HTMLElement::class) && !empty(trim($el->val())) && $status === Constants::STATUS_PUBLISHED) {
+            if (
+                is_a($el, \dokuwiki\Form\HTMLElement::class) &&
+                !empty(trim($el->val())) &&
+                $status === Constants::STATUS_PUBLISHED
+            ) {
                 $val = $el->val();
-                $label = '<span class="plugin-structpublish-version">' . $status . ' (' . $this->getLang('version') . ' ' . $version . ')</span>';
+                $label = '<span class="plugin-structpublish-version">' .
+                    $status . ' (' . $this->getLang('version') . ' ' . $version . ')</span>';
                 $el->val("$val $label");
             }
         }

--- a/action/save.php
+++ b/action/save.php
@@ -41,7 +41,7 @@ class action_plugin_structpublish_save extends DokuWiki_Action_Plugin
 
         try {
             $revision->save();
-        } catch(StructException $e) {
+        } catch (StructException $e) {
             msg($e->getMessage(), -1);
         }
     }

--- a/action/show.php
+++ b/action/show.php
@@ -6,7 +6,7 @@ use dokuwiki\plugin\structpublish\meta\Revision;
 class action_plugin_structpublish_show extends DokuWiki_Action_Plugin
 {
     /** @var int */
-    static protected $latestPublishedRev;
+    protected static $latestPublishedRev;
 
     /** @inheritDoc */
     public function register(Doku_Event_Handler $controller)

--- a/admin.php
+++ b/admin.php
@@ -37,7 +37,7 @@ class admin_plugin_structpublish extends DokuWiki_Admin_Plugin
 
         try {
             $assignments = Assignments::getInstance();
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             msg($e->getMessage(), -1);
             return;
         }
@@ -46,8 +46,11 @@ class admin_plugin_structpublish extends DokuWiki_Admin_Plugin
             $assignment = $INPUT->arr('assignment');
             if (!blank($assignment['pattern']) && !blank($assignment['status'])) {
                 if ($INPUT->str('action') === 'delete') {
-                    $ok = $assignments->removePattern($assignment['pattern'], $assignment['user'],
-                        $assignment['status']);
+                    $ok = $assignments->removePattern(
+                        $assignment['pattern'],
+                        $assignment['user'],
+                        $assignment['status']
+                    );
                     if (!$ok) {
                         msg('failed to remove pattern', -1);
                     }
@@ -56,15 +59,21 @@ class admin_plugin_structpublish extends DokuWiki_Admin_Plugin
                         if (@preg_match($assignment['pattern'], null) === false) {
                             msg('Invalid regular expression. Pattern not saved', -1);
                         } else {
-                            $ok = $assignments->addPattern($assignment['pattern'], $assignment['user'],
-                                $assignment['status']);
+                            $ok = $assignments->addPattern(
+                                $assignment['pattern'],
+                                $assignment['user'],
+                                $assignment['status']
+                            );
                             if (!$ok) {
                                 msg('failed to add pattern', -1);
                             }
                         }
                     } else {
-                        $ok = $assignments->addPattern($assignment['pattern'], $assignment['user'],
-                            $assignment['status']);
+                        $ok = $assignments->addPattern(
+                            $assignment['pattern'],
+                            $assignment['user'],
+                            $assignment['status']
+                        );
                         if (!$ok) {
                             msg('failed to add pattern', -1);
                         }
@@ -87,7 +96,7 @@ class admin_plugin_structpublish extends DokuWiki_Admin_Plugin
 
         try {
             $assignments = Assignments::getInstance();
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             msg($e->getMessage(), -1);
             return;
         }
@@ -152,4 +161,3 @@ class admin_plugin_structpublish extends DokuWiki_Admin_Plugin
         echo '</form>';
     }
 }
-

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Default settings for the structpublish plugin
  *

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Options for the structpublish plugin
  *

--- a/helper/assignments.php
+++ b/helper/assignments.php
@@ -16,7 +16,6 @@ class helper_plugin_structpublish_assignments extends DokuWiki_Plugin
      * @param string|null $pns optimization, the colon wrapped namespace of the page, set null for automatic
      * @return bool
      * @author Andreas Gohr
-     *
      */
     public function matchPagePattern($pattern, $page, $pns = null)
     {

--- a/helper/db.php
+++ b/helper/db.php
@@ -17,15 +17,17 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
     {
         /** @var helper_plugin_struct_db $struct */
         $struct = plugin_load('helper', 'struct_db');
-        if(!$struct) {
+        if (!$struct) {
             // FIXME show message?
             return null;
         }
         $sqlite = $struct->getDB(false);
-        if(!$sqlite) return null;
+        if (!$sqlite) {
+            return null;
+        }
 
         // on init
-        if(!$this->initialized) {
+        if (!$this->initialized) {
             $sqlite->getPdo()->sqliteCreateFunction('IS_PUBLISHER', [$this, 'isPublisher'], -1);
             $this->initialized = true;
         }
@@ -35,12 +37,15 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
 
     /**
      * Get list of all pages known to the plugin
+     *
      * @return array
      */
     public function getPages()
     {
         $sqlite = $this->getDB();
-        if(!$sqlite) return [];
+        if (!$sqlite) {
+            return [];
+        }
 
         $sql = 'SELECT pid FROM titles';
         $list = $sqlite->queryAll($sql);
@@ -57,9 +62,13 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
     {
         global $ID;
         $sqlite = $this->getDB();
-        if(!$sqlite) return false;
+        if (!$sqlite) {
+            return false;
+        }
 
-        if (!$pid) $pid = $ID;
+        if (!$pid) {
+            $pid = $ID;
+        }
 
         $sql = 'SELECT pid FROM structpublish_assignments WHERE pid = ? AND assigned = 1';
         return (bool) $sqlite->queryAll($sql, $pid);
@@ -94,9 +103,7 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
         $args = func_get_args();
         $pid = $args[0];
 
-        if (!$pid) return 1;
-
-        if (!$this->isPublishable($pid)) {
+        if (!$pid || !$this->isPublishable($pid)) {
             return 1;
         }
 
@@ -152,5 +159,4 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
 
         return false;
     }
-
 }

--- a/helper/db.php
+++ b/helper/db.php
@@ -48,18 +48,21 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
     }
 
     /**
-     * Returns true if the current page is included in publishing workflows
+     * Returns true if the given page is included in publishing workflows.
+     * If no pid is given, check current page.
      *
      * @return bool
      */
-    public function isPublishable()
+    public function isPublishable($pid = null)
     {
         global $ID;
         $sqlite = $this->getDB();
         if(!$sqlite) return false;
 
+        if (!$pid) $pid = $ID;
+
         $sql = 'SELECT pid FROM structpublish_assignments WHERE pid = ? AND assigned = 1';
-        return (bool) $sqlite->queryAll($sql, $ID);
+        return (bool) $sqlite->queryAll($sql, $pid);
     }
 
     /**
@@ -84,13 +87,19 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
      */
     public function isPublisher()
     {
-        if (!$this->isPublishable()) return 1;
 
         global $USERINFO;
         global $INPUT;
 
         $args = func_get_args();
         $pid = $args[0];
+
+        if (!$pid) return 1;
+
+        if (!$this->isPublishable($pid)) {
+            return 1;
+        }
+
         $userId = $args[1] ?? $INPUT->server->str('REMOTE_USER');
         $grps = $args[2] ?? ($USERINFO['grps'] ?? []);
 

--- a/helper/notify.php
+++ b/helper/notify.php
@@ -29,7 +29,9 @@ class helper_plugin_structpublish_notify extends DokuWiki_Plugin
     public function sendEmails($action, $newRevision)
     {
 
-        if (!$this->triggerNotification($action)) return;
+        if (!$this->triggerNotification($action)) {
+            return;
+        }
 
         // get assignees from DB
         $assignments = Assignments::getInstance();
@@ -37,7 +39,9 @@ class helper_plugin_structpublish_notify extends DokuWiki_Plugin
 
         // get recipients for the next workflow step
         $nextAction = Constants::workflowSteps($action)['nextAction'];
-        if (is_null($nextAction)) return;
+        if (is_null($nextAction)) {
+            return;
+        }
 
         if (empty($assignees[$nextAction])) {
             msg($this->getLang('email_error_norecipients'), -1);
@@ -133,7 +137,9 @@ class helper_plugin_structpublish_notify extends DokuWiki_Plugin
         /** @var AuthPlugin $auth */
         global $auth;
         $user = $auth->getUserData($recipient);
-        if ($user) $resolved[] = $user['mail'];
+        if ($user) {
+            $resolved[] = $user['mail'];
+        }
     }
 
     /**
@@ -143,7 +149,9 @@ class helper_plugin_structpublish_notify extends DokuWiki_Plugin
      */
     private function triggerNotification($action)
     {
-        if (!$this->getConf('email_enable')) return false;
+        if (!$this->getConf('email_enable')) {
+            return false;
+        }
 
         $actions = array_map('trim', explode(',', $this->getConf('email_status')));
         return in_array($action, $actions);

--- a/helper/publish.php
+++ b/helper/publish.php
@@ -12,7 +12,6 @@ use dokuwiki\plugin\structpublish\meta\Revision;
  */
 class helper_plugin_structpublish_publish extends DokuWiki_Plugin
 {
-
     /** @var helper_plugin_structpublish_db  */
     protected $dbHelper;
 
@@ -33,9 +32,7 @@ class helper_plugin_structpublish_publish extends DokuWiki_Plugin
         global $ID;
         global $INFO;
 
-        if (
-            !$this->dbHelper->checkAccess($ID, [$action])
-        ) {
+        if (!$this->dbHelper->checkAccess($ID, [$action])) {
             throw new \Exception('User may not ' . $action);
         }
 
@@ -81,10 +78,14 @@ class helper_plugin_structpublish_publish extends DokuWiki_Plugin
             $sqlite->query("UPDATE multi_$table SET published = 0 WHERE pid = ?", [$ID]);
 
             // publish the current revision
-            $sqlite->query("UPDATE data_$table SET published = 1 WHERE pid = ? AND rev = ?",
-                [$ID, $INFO['currentrev']]);
-            $sqlite->query("UPDATE multi_$table SET published = 1 WHERE pid = ? AND rev = ?",
-                [$ID, $INFO['currentrev']]);
+            $sqlite->query(
+                "UPDATE data_$table SET published = 1 WHERE pid = ? AND rev = ?",
+                [$ID, $INFO['currentrev']]
+            );
+            $sqlite->query(
+                "UPDATE multi_$table SET published = 1 WHERE pid = ? AND rev = ?",
+                [$ID, $INFO['currentrev']]
+            );
         }
     }
 }

--- a/meta/Assignments.php
+++ b/meta/Assignments.php
@@ -26,7 +26,7 @@ class Assignments
     /**
      * Get the singleton instance of the Assignments
      *
-     * @param bool $forcereload create a new instace to reload the assignment data
+     * @param bool $forcereload create a new instance to reload the assignment data
      * @return Assignments
      */
     public static function getInstance($forcereload = false)

--- a/meta/Constants.php
+++ b/meta/Constants.php
@@ -18,7 +18,6 @@ class Constants
     const ACTION_APPROVE = 'approve';
     const ACTION_PUBLISH = 'publish';
 
-
     /**
      * Convenience function mapping transition actions to resulting status
      *

--- a/meta/Revision.php
+++ b/meta/Revision.php
@@ -65,6 +65,7 @@ class Revision
 
     /**
      * Store the currently set structpublish meta data in the database
+     *
      * @return void
      */
     public function save()
@@ -197,6 +198,7 @@ class Revision
 
     /**
      * The page ID this revision is for
+     *
      * @return string
      */
     public function getId()
@@ -229,6 +231,7 @@ class Revision
      * Fetches data from the structpublish schema for the current page.
      * Returns an array of struct Value objects, not literal values.
      * $andFilters can be used to limit the search, e.g. by status or revision
+     *
      * @see https://www.dokuwiki.org/plugin:struct:filters
      *
      * @param array $andFilters
@@ -244,8 +247,9 @@ class Revision
         ];
 
         if (!empty($andFilters)) {
-            foreach ($andFilters as $filter)
-            $lines[] = 'filter: ' . $filter;
+            foreach ($andFilters as $filter) {
+                $lines[] = 'filter: ' . $filter;
+            }
         }
 
         $parser = new ConfigParser($lines);
@@ -279,8 +283,10 @@ class Revision
             return null;
         }
 
-        $published = new Revision($this->id,
-            $latestPublished[$this->revisionCol->getColref() - 1]->getRawValue());
+        $published = new Revision(
+            $this->id,
+            $latestPublished[$this->revisionCol->getColref() - 1]->getRawValue()
+        );
 
         $published->setStatus($latestPublished[$this->statusCol->getColref() - 1]->getRawValue());
         $published->setUser($latestPublished[$this->userCol->getColref() - 1]->getRawValue());


### PR DESCRIPTION
Addressed issue: struct aggregations on pages under structpublish control sometimes falsely show no results.

Reason: `isPublisher()` check worked on the false page id.