### PR TITLE
publish needs approve option + fr translation

### DIFF
--- a/action/banner.php
+++ b/action/banner.php
@@ -148,32 +148,71 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
      */
     protected function actionButtons($status, $newVersion)
     {
+
         global $ID;
+
+        // If the status is published, return an empty string
         if ($status === Constants::STATUS_PUBLISHED) {
             return '';
         }
 
-        $form = new dokuwiki\Form\Form();
+        if ((bool)$this->getConf('publish_needs_approve')){
 
-        if (
-            $status !== Constants::STATUS_APPROVED &&
-            $this->dbHelper->checkAccess($ID, [Constants::ACTION_APPROVE])
-        ) {
-            $form->addButton(
-                'structpublish[' . Constants::ACTION_APPROVE . ']',
-                $this->getLang('action_' . Constants::ACTION_APPROVE)
-            )->attr('type', 'submit');
+        /**
+        * begin code by sarmacrea
+        */   
+                // Create a new form instance
+                $form = new dokuwiki\Form\Form();
+
+                // Add the approve button if the status is not approved and the user has access
+                if (
+                        $status !== Constants::STATUS_APPROVED &&
+                        $this->dbHelper->checkAccess($ID, [Constants::ACTION_APPROVE])
+                ) {
+                        $form->addButton(
+                        'structpublish[' . Constants::ACTION_APPROVE . ']',
+                        $this->getLang('action_' . Constants::ACTION_APPROVE)
+                        )->attr('type', 'submit');
+                }
+
+                // Add the publish button only if the status is approved and the user has access
+                if ($status === Constants::STATUS_APPROVED && $this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
+                        $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
+                        $form->addButton(
+                        'structpublish[' . Constants::ACTION_PUBLISH . ']',
+                        $this->getLang('action_' . Constants::ACTION_PUBLISH)
+                        )->attr('type', 'submit');
+                }
+        /**
+        * end code by sarmacrea
+        */
+
+        } else {
+
+                $form = new dokuwiki\Form\Form();
+
+                if (
+                        $status !== Constants::STATUS_APPROVED &&
+                        $this->dbHelper->checkAccess($ID, [Constants::ACTION_APPROVE])
+                ) {
+                        $form->addButton(
+                        'structpublish[' . Constants::ACTION_APPROVE . ']',
+                        $this->getLang('action_' . Constants::ACTION_APPROVE)
+                        )->attr('type', 'submit');
+                }
+
+                if ($this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
+                        $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
+                        $form->addButton(
+                                'structpublish[' . Constants::ACTION_PUBLISH . ']',
+                                $this->getLang('action_' . Constants::ACTION_PUBLISH)
+                        )->attr('type', 'submit');
+                }
+
         }
 
-        if ($this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
-            $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
-            $form->addButton(
-                'structpublish[' . Constants::ACTION_PUBLISH . ']',
-                $this->getLang('action_' . Constants::ACTION_PUBLISH)
-            )->attr('type', 'submit');
-        }
-
-        return $form->toHTML();
+       // Return the HTML representation of the form
+       return $form->toHTML();
     }
 
     /**

--- a/conf/default.php
+++ b/conf/default.php
@@ -10,3 +10,4 @@ $conf['restrict_admin'] = 1;
 $conf['email_enable'] = 0;
 $conf['email_status'] = '';
 $conf['compact_view'] = 0;
+$conf['publish_needs_approve'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -10,3 +10,4 @@ $meta['restrict_admin'] = ['onoff'];
 $meta['email_enable'] = ['onoff'];
 $meta['email_status'] = ['multicheckbox', '_other' => 'never', '_choices' => ['approve', 'publish']];
 $meta['compact_view'] = ['onoff'];
+$meta['publish_needs_approve'] = ['onoff'];

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Regeln gelten auch für Superusers. Wenn deaktiviert,
 $lang['email_enable'] = 'E-Mails aktivieren';
 $lang['email_status'] = 'Bei welchen Statusänderungen sollen E-Mails versendet werden?';
 $lang['compact_view'] = 'Kompakter Banner';
+$lang['publish_needs_approve'] = 'Seiten müssen vor ihrer Veröffentlichung genehmigt werden';
+

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Publishing rules apply to superusers too. Uncheck if 
 $lang['email_enable'] = 'Send emails';
 $lang['email_status'] = 'Status changes that trigger emails';
 $lang['compact_view'] = 'Compact banner';
+$lang['publish_needs_approve'] = 'Pages must be approved before being published';
+

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * french language file for structpublish plugin
+ *
+ * @author Josquin DEHAENE <josquin@moka.works>
+ */
+
+// entrée du menu pour les plugins d'administration
+$lang['menu'] = 'Données de publication structurées';
+
+// banner
+$lang['version'] = 'Version';
+$lang['newversion'] = 'Nouvelle version';
+$lang['status'] = 'Statut de publication de la page que vous consultez actuellement';
+$lang['actions'] = 'Actions';
+$lang['status_draft'] = 'Brouillon';
+$lang['status_approved'] = 'Approuvé';
+$lang['status_published'] = 'Publié';
+$lang['action_approve'] = 'Approuver';
+$lang['action_publish'] = 'Publier';
+
+$lang['diff'] = 'Afficher les différences';
+$lang['banner_status_draft'] = 'Cette révision de la page est un <strong>brouillon en cours</strong>, créé le {revision}.';
+$lang['banner_status_approved'] = 'Cette révision de la page a été <strong>approuvée pour publication</strong> le {datetime} par {user}.';
+$lang['banner_status_published'] = 'Cette révision de la page a été <strong>publiée <span class="plugin-structpublish-version">en tant que version "{version}"</span></strong> le {datetime} par {user}.';
+$lang['banner_latest_publish'] = 'La page a été publiée pour la dernière fois en tant que version {version} par {user} le {datetime}.';
+$lang['banner_previous_publish'] = 'La page a été précédemment publiée en tant que version {version} par {user} le {datetime}.';
+$lang['banner_latest_draft'] = 'Un brouillon plus récent a été créé le {revision}.';
+$lang['compact_banner_status_draft'] = 'Brouillon';
+$lang['compact_banner_status_approved'] = 'Approuvé';
+$lang['compact_banner_status_published'] = 'Publié en tant que version "{version}" le {datetime} par {user}';
+$lang['compact_banner_latest_publish'] = '';
+$lang['compact_banner_previous_publish'] = '';
+$lang['compact_banner_latest_draft'] = 'Brouillon plus récent : {revision}';
+
+// admin
+$lang['assign_pattern'] = 'Modèle';
+$lang['assign_user'] = 'Utilisateur ou @group';
+$lang['assign_status'] = 'Statut';
+$lang['assign_add'] = 'Ajouter une attribution';
+$lang['assign_del'] = 'Supprimer une attribution';
+
+// email
+$lang['email_subject'] = 'Le statut de publication d’une page wiki a changé';
+$lang['email_error_norecipients'] = 'Aucun destinataire trouvé pour la notification !';
+

--- a/lang/fr/mail.txt
+++ b/lang/fr/mail.txt
@@ -1,0 +1,5 @@
+Bonjour,
+
+Ceci est une notification pour vous informer que le statut de la page « @PAGE@ » a changé pour @STATUS_CURRENT@.
+
+Vous pouvez agir dessus ici : @URL@

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -1,0 +1,8 @@
+<?php
+
+$lang['restrict_admin'] = 'Les règles de publication s’appliquent également aux super-utilisateurs. Décochez cette option si les administrateurs doivent voir les révisions non publiées même s’ils ne sont pas éditeurs.';
+$lang['email_enable'] = 'Envoyer des e-mails';
+$lang['email_status'] = 'Changements de statut déclenchant l’envoi d’e-mails';
+$lang['compact_view'] = 'Bannière compacte';
+$lang['publish_needs_approve'] = 'Les pages doivent être approuvées avant d’être publiées';
+

--- a/lang/it/settings.php
+++ b/lang/it/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Le regole di pubblicazione vengono applicate anche ag
 $lang['email_enable'] = 'Invia e-mail';
 $lang['email_status'] = 'Modifiche dello stato che attivano le notifiche via e-mail';
 $lang['compact_view'] = 'Banner compatto';
+$lang['publish_needs_approve'] = 'Le pagine devono essere approvate prima di essere pubblicate';
+


### PR DESCRIPTION
feat: Add "Publish Needs Approval" option & French translation  

- Implemented a "Publish Needs Approval" option for content moderation  (based on sarmacrea code)
- Added French translation for the plugin  

