### PR TITLE
Enforce Approval Before Publishing & Prevent Duplicates

### DIFF
--- a/action/banner.php
+++ b/action/banner.php
@@ -9,13 +9,19 @@ use dokuwiki\plugin\structpublish\meta\Revision;
  */
 class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
 {
-    /** @var \helper_plugin_structpublish_db */
+    /**
+     * @var \helper_plugin_structpublish_db 
+     */
     protected $dbHelper;
 
-    /** @var bool */
+    /**
+     * @var bool 
+     */
     protected $compactView;
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc 
+     */
     public function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('TPL_ACT_RENDER', 'BEFORE', $this, 'renderBanner');
@@ -69,10 +75,9 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
         }
 
         // link to newest draft, if exists, is not shown already and user has a role
-        if (
-            $newestRevision->getRev() != $shownRevision->getRev() &&
-            $newestRevision->getStatus() != Constants::STATUS_PUBLISHED &&
-            $this->dbHelper->checkAccess($ID)
+        if ($newestRevision->getRev() != $shownRevision->getRev() 
+            && $newestRevision->getStatus() != Constants::STATUS_PUBLISHED 
+            && $this->dbHelper->checkAccess($ID)
         ) {
             $banner .= $this->getBannerText('latest_draft', $newestRevision, $shownRevision->getRev());
         }
@@ -92,8 +97,8 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
     /**
      * Fills place holder texts with data from the given Revision
      *
-     * @param string $name
-     * @param Revision $rev
+     * @param  string   $name
+     * @param  Revision $rev
      * @return string
      */
     protected function getBannerText($name, $rev, $diff = '')
@@ -128,9 +133,9 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
     /**
      * Create a HTML link to a specific revision
      *
-     * @param string $id page id
-     * @param int $rev revision to link to
-     * @param int $text the link text to use
+     * @param  string $id   page id
+     * @param  int    $rev  revision to link to
+     * @param  int    $text the link text to use
      * @return string
      */
     protected function makeLink($id, $rev, $text)
@@ -142,44 +147,61 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
     /**
      * Create the form for approval and publishing
      *
-     * @param string $status current status
-     * @param string $newVersion suggested new Version
+     * @param  string $status     current status
+     * @param  string $newVersion suggested new Version
      * @return string
      */
     protected function actionButtons($status, $newVersion)
     {
+
         global $ID;
+
+        // If the status is published, return an empty string
         if ($status === Constants::STATUS_PUBLISHED) {
             return '';
         }
 
+        // Create a new form instance
         $form = new dokuwiki\Form\Form();
 
-        if (
-            $status !== Constants::STATUS_APPROVED &&
-            $this->dbHelper->checkAccess($ID, [Constants::ACTION_APPROVE])
+
+        if ($status !== Constants::STATUS_APPROVED 
+            && $this->dbHelper->checkAccess($ID, [Constants::ACTION_APPROVE])
         ) {
-            $form->addButton(
-                'structpublish[' . Constants::ACTION_APPROVE . ']',
-                $this->getLang('action_' . Constants::ACTION_APPROVE)
-            )->attr('type', 'submit');
+                $form->addButton(
+                    'structpublish[' . Constants::ACTION_APPROVE . ']',
+                    $this->getLang('action_' . Constants::ACTION_APPROVE)
+                )->attr('type', 'submit');
         }
 
-        if ($this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
-            $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
-            $form->addButton(
-                'structpublish[' . Constants::ACTION_PUBLISH . ']',
-                $this->getLang('action_' . Constants::ACTION_PUBLISH)
-            )->attr('type', 'submit');
-        }
+           // Add the publish button only if the status is approved and the user has access
+        if ((bool)$this->getConf('publish_needs_approve')) {
+            if ($status === Constants::STATUS_APPROVED && $this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
+                $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
+                $form->addButton(
+                    'structpublish[' . Constants::ACTION_PUBLISH . ']',
+                    $this->getLang('action_' . Constants::ACTION_PUBLISH)
+                )->attr('type', 'submit');
+            }
+        } else {
+            if ($this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
+                $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
+                $form->addButton(
+                    'structpublish[' . Constants::ACTION_PUBLISH . ']',
+                    $this->getLang('action_' . Constants::ACTION_PUBLISH)
+                )->attr('type', 'submit');
+            }
 
+        }
+        // Return the HTML representation of the form
         return $form->toHTML();
     }
+
 
     /**
      * Tries to increase a given version
      *
-     * @param string $version
+     * @param  string $version
      * @return string
      */
     protected function increaseVersion($version)

--- a/conf/default.php
+++ b/conf/default.php
@@ -10,3 +10,4 @@ $conf['restrict_admin'] = 1;
 $conf['email_enable'] = 0;
 $conf['email_status'] = '';
 $conf['compact_view'] = 0;
+$conf['publish_needs_approve'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -10,3 +10,4 @@ $meta['restrict_admin'] = ['onoff'];
 $meta['email_enable'] = ['onoff'];
 $meta['email_status'] = ['multicheckbox', '_other' => 'never', '_choices' => ['approve', 'publish']];
 $meta['compact_view'] = ['onoff'];
+$meta['publish_needs_approve'] = ['onoff'];

--- a/helper/publish.php
+++ b/helper/publish.php
@@ -12,7 +12,9 @@ use dokuwiki\plugin\structpublish\meta\Revision;
  */
 class helper_plugin_structpublish_publish extends DokuWiki_Plugin
 {
-    /** @var helper_plugin_structpublish_db  */
+    /**
+     * @var helper_plugin_structpublish_db  
+     */
     protected $dbHelper;
 
     public function __construct()
@@ -23,7 +25,7 @@ class helper_plugin_structpublish_publish extends DokuWiki_Plugin
     /**
      * Save publish data
      *
-     * @param string $action
+     * @param  string $action
      * @return Revision
      * @throws Exception
      */
@@ -37,6 +39,15 @@ class helper_plugin_structpublish_publish extends DokuWiki_Plugin
         }
 
         $revision = new Revision($ID, $INFO['currentrev']);
+
+        //do nothing if action is approve and the current revison have already been approved 
+        if ($action === Constants::ACTION_APPROVE && $revision->getLatestApprovedRevision() !== null && $revision->getRev() == $revision->getLatestApprovedRevision()->getRev()) {
+            return $revision;
+        }
+        //do nothing if action is publish and the current revison have already been published 
+        if ($action === Constants::ACTION_PUBLISH && $revision->getLatestPublishedRevision() !== null && $revision->getRev() == $revision->getLatestPublishedRevision()->getRev()) {
+            return $revision;
+        }
 
         if ($action === Constants::ACTION_PUBLISH) {
             $revision->setVersion($newversion);

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Regeln gelten auch für Superusers. Wenn deaktiviert,
 $lang['email_enable'] = 'E-Mails aktivieren';
 $lang['email_status'] = 'Bei welchen Statusänderungen sollen E-Mails versendet werden?';
 $lang['compact_view'] = 'Kompakter Banner';
+$lang['publish_needs_approve'] = 'Seiten müssen vor ihrer Veröffentlichung genehmigt werden';
+

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Publishing rules apply to superusers too. Uncheck if 
 $lang['email_enable'] = 'Send emails';
 $lang['email_status'] = 'Status changes that trigger emails';
 $lang['compact_view'] = 'Compact banner';
+$lang['publish_needs_approve'] = 'Pages must be approved before being published';
+

--- a/lang/it/settings.php
+++ b/lang/it/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Le regole di pubblicazione vengono applicate anche ag
 $lang['email_enable'] = 'Invia e-mail';
 $lang['email_status'] = 'Modifiche dello stato che attivano le notifiche via e-mail';
 $lang['compact_view'] = 'Banner compatto';
+$lang['publish_needs_approve'] = 'Le pagine devono essere approvate prima di essere pubblicate';
+

--- a/meta/Revision.php
+++ b/meta/Revision.php
@@ -13,7 +13,9 @@ use dokuwiki\plugin\struct\meta\Value;
  */
 class Revision
 {
-    /** @var SQLiteDB */
+    /**
+     * @var SQLiteDB 
+     */
     protected $sqlite;
 
     protected $schema;
@@ -25,7 +27,9 @@ class Revision
     protected $version;
     protected $user;
     protected $datetime;
-    /** @var bool|\dokuwiki\plugin\struct\meta\Column */
+    /**
+     * @var bool|\dokuwiki\plugin\struct\meta\Column 
+     */
     protected $statusCol;
     protected $versionCol;
     protected $userCol;
@@ -35,8 +39,8 @@ class Revision
     /**
      * Constructor
      *
-     * @param string $id page id
-     * @param int $rev revision
+     * @param string $id  page id
+     * @param int    $rev revision
      */
     public function __construct($id, $rev)
     {
@@ -52,7 +56,9 @@ class Revision
         $this->datetimeCol = $this->schema->findColumn('datetime');
         $this->revisionCol = $this->schema->findColumn('revision');
 
-        /** @var Value[] $values */
+        /**
+ * @var Value[] $values 
+*/
         $values = $this->getCoreData(['revision=' . $this->rev]);
 
         if (!empty($values)) {
@@ -210,7 +216,7 @@ class Revision
      * Update publish status in the core table
      *
      * @param string $pid
-     * @param int $rid
+     * @param int    $rid
      */
     protected function updateCoreData($pid, $rid = 0)
     {
@@ -234,7 +240,7 @@ class Revision
      *
      * @see https://www.dokuwiki.org/plugin:struct:filters
      *
-     * @param array $andFilters
+     * @param  array $andFilters
      * @return array|Value[]
      */
     public function getCoreData($andFilters = [])
@@ -268,7 +274,7 @@ class Revision
      * Return "latest" published revision of a given page.
      * If $rev is specified, "latest" means relative to the $rev revision.
      *
-     * @param int|null $rev
+     * @param  int|null $rev
      * @return Revision|null
      */
     public function getLatestPublishedRevision($rev = null)
@@ -294,5 +300,37 @@ class Revision
         $published->setVersion($latestPublished[$this->versionCol->getColref() - 1]->getRawValue());
 
         return $published;
+    }
+
+    /**
+     * Return "latest" approved revision of a given page.
+     * If $rev is specified, "latest" means relative to the $rev revision.
+     *
+     * @param  int|null $rev
+     * @return Revision|null
+     */
+    public function getLatestApprovedRevision($rev = null)
+    {
+        $andFilters[] = 'status=' . Constants::STATUS_APPROVED;
+        if ($rev) {
+            $andFilters[] .= 'revision=' . $rev;
+        }
+        $latestApproved = $this->getCoreData($andFilters);
+
+        if (empty($latestApproved)) {
+            return null;
+        }
+
+        $approved = new Revision(
+            $this->id,
+            $latestApproved[$this->revisionCol->getColref() - 1]->getRawValue()
+        );
+
+        $approved->setStatus($latestApproved[$this->statusCol->getColref() - 1]->getRawValue());
+        $approved->setUser($latestApproved[$this->userCol->getColref() - 1]->getRawValue());
+        $approved->setDatetime($latestApproved[$this->datetimeCol->getColref() - 1]->getRawValue());
+        $approved->setVersion($latestApproved[$this->versionCol->getColref() - 1]->getRawValue());
+
+        return $approved;
     }
 }


### PR DESCRIPTION
Adds a `publish_needs_approve` option to require approval before publishing. Also prevents approving or publishing a revision that has already been approved/published to avoid database duplicates.

- Added `publish_needs_approve` option.
- Check if a revision has already been approved/published before proceeding.