### PR TITLE
Add `publish_needs_approve` option to enforce approval before publishing

### DIFF
--- a/action/banner.php
+++ b/action/banner.php
@@ -74,10 +74,10 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
             $banner .= $this->getBannerText('previous_publish', $prevpubRevision, $shownRevision->getRev());
         }
 
-        // link to newest draft, if exists, is not shown already and user has a role
+        // link to newest draft, if exists, if not shown already, if user has ACL write
         if ($newestRevision->getRev() != $shownRevision->getRev() 
             && $newestRevision->getStatus() != Constants::STATUS_PUBLISHED 
-            && $this->dbHelper->checkAccess($ID)
+            && auth_quickaclcheck($ID) >= 2
         ) {
             $banner .= $this->getBannerText('latest_draft', $newestRevision, $shownRevision->getRev());
         }

--- a/action/banner.php
+++ b/action/banner.php
@@ -9,13 +9,19 @@ use dokuwiki\plugin\structpublish\meta\Revision;
  */
 class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
 {
-    /** @var \helper_plugin_structpublish_db */
+    /**
+     * @var \helper_plugin_structpublish_db 
+     */
     protected $dbHelper;
 
-    /** @var bool */
+    /**
+     * @var bool 
+     */
     protected $compactView;
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc 
+     */
     public function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('TPL_ACT_RENDER', 'BEFORE', $this, 'renderBanner');
@@ -69,10 +75,9 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
         }
 
         // link to newest draft, if exists, is not shown already and user has a role
-        if (
-            $newestRevision->getRev() != $shownRevision->getRev() &&
-            $newestRevision->getStatus() != Constants::STATUS_PUBLISHED &&
-            $this->dbHelper->checkAccess($ID)
+        if ($newestRevision->getRev() != $shownRevision->getRev() 
+            && $newestRevision->getStatus() != Constants::STATUS_PUBLISHED 
+            && $this->dbHelper->checkAccess($ID)
         ) {
             $banner .= $this->getBannerText('latest_draft', $newestRevision, $shownRevision->getRev());
         }
@@ -92,8 +97,8 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
     /**
      * Fills place holder texts with data from the given Revision
      *
-     * @param string $name
-     * @param Revision $rev
+     * @param  string   $name
+     * @param  Revision $rev
      * @return string
      */
     protected function getBannerText($name, $rev, $diff = '')
@@ -128,9 +133,9 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
     /**
      * Create a HTML link to a specific revision
      *
-     * @param string $id page id
-     * @param int $rev revision to link to
-     * @param int $text the link text to use
+     * @param  string $id   page id
+     * @param  int    $rev  revision to link to
+     * @param  int    $text the link text to use
      * @return string
      */
     protected function makeLink($id, $rev, $text)
@@ -142,44 +147,61 @@ class action_plugin_structpublish_banner extends DokuWiki_Action_Plugin
     /**
      * Create the form for approval and publishing
      *
-     * @param string $status current status
-     * @param string $newVersion suggested new Version
+     * @param  string $status     current status
+     * @param  string $newVersion suggested new Version
      * @return string
      */
     protected function actionButtons($status, $newVersion)
     {
+
         global $ID;
+
+        // If the status is published, return an empty string
         if ($status === Constants::STATUS_PUBLISHED) {
             return '';
         }
 
+        // Create a new form instance
         $form = new dokuwiki\Form\Form();
 
-        if (
-            $status !== Constants::STATUS_APPROVED &&
-            $this->dbHelper->checkAccess($ID, [Constants::ACTION_APPROVE])
+
+        if ($status !== Constants::STATUS_APPROVED 
+            && $this->dbHelper->checkAccess($ID, [Constants::ACTION_APPROVE])
         ) {
-            $form->addButton(
-                'structpublish[' . Constants::ACTION_APPROVE . ']',
-                $this->getLang('action_' . Constants::ACTION_APPROVE)
-            )->attr('type', 'submit');
+                $form->addButton(
+                    'structpublish[' . Constants::ACTION_APPROVE . ']',
+                    $this->getLang('action_' . Constants::ACTION_APPROVE)
+                )->attr('type', 'submit');
         }
 
-        if ($this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
-            $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
-            $form->addButton(
-                'structpublish[' . Constants::ACTION_PUBLISH . ']',
-                $this->getLang('action_' . Constants::ACTION_PUBLISH)
-            )->attr('type', 'submit');
-        }
+           // Add the publish button only if the status is approved and the user has access
+        if ((bool)$this->getConf('publish_needs_approve')) {
+            if ($status === Constants::STATUS_APPROVED && $this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
+                $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
+                $form->addButton(
+                    'structpublish[' . Constants::ACTION_PUBLISH . ']',
+                    $this->getLang('action_' . Constants::ACTION_PUBLISH)
+                )->attr('type', 'submit');
+            }
+        } else {
+            if ($this->dbHelper->checkAccess($ID, [Constants::ACTION_PUBLISH])) {
+                $form->addTextInput('version', $this->getLang('newversion'))->val($newVersion);
+                $form->addButton(
+                    'structpublish[' . Constants::ACTION_PUBLISH . ']',
+                    $this->getLang('action_' . Constants::ACTION_PUBLISH)
+                )->attr('type', 'submit');
+            }
 
+        }
+        // Return the HTML representation of the form
         return $form->toHTML();
     }
+
 
     /**
      * Tries to increase a given version
      *
-     * @param string $version
+     * @param  string $version
      * @return string
      */
     protected function increaseVersion($version)

--- a/action/dw2pdf.php
+++ b/action/dw2pdf.php
@@ -6,14 +6,14 @@ use dokuwiki\plugin\structpublish\meta\Revision;
 /**
  * Action component providing (localized) dw2pdf replacements
  *
- * @STATUS@        draft / approved / published
- * @APPROVER@      user that approved the draft
- * @APPROVALDATE@  date of approval
- * @PUBLISHER@     user that published the page
- * @PUBLISHDATE@   date of publishing
- * @VERSION@       shown version
- * @REVISION@      shown revision
- * @LATESTPUBLISHEDVERSION@ latest published version
+ * @STATUS@                  draft / approved / published
+ * @APPROVER@                user that approved the draft
+ * @APPROVALDATE@            date of approval
+ * @PUBLISHER@               user that published the page
+ * @PUBLISHDATE@             date of publishing
+ * @VERSION@                 shown version
+ * @REVISION@                shown revision
+ * @LATESTPUBLISHEDVERSION@  latest published version
  * @LATESTPUBLISHEDREVISION@ latest published revision
  *
  * @author  Josquin Dehaene <jo@foobarjo.org>
@@ -46,6 +46,7 @@ class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
         $keep = $ID;
         $ID = $event->data['id']; 
         $INFO = pageinfo();
+        $REV = $event->data['rev'];
 
         $this->dbHelper = plugin_load('helper', 'structpublish_db');
 

--- a/action/dw2pdf.php
+++ b/action/dw2pdf.php
@@ -46,7 +46,6 @@ class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
         $keep = $ID;
         $ID = $event->data['id']; 
         $INFO = pageinfo();
-        $REV = null;
 
         $this->dbHelper = plugin_load('helper', 'structpublish_db');
 

--- a/action/dw2pdf.php
+++ b/action/dw2pdf.php
@@ -1,0 +1,115 @@
+<?php
+
+use dokuwiki\plugin\structpublish\meta\Constants;
+use dokuwiki\plugin\structpublish\meta\Revision;
+
+/**
+ * Action component providing (localized) dw2pdf replacements
+ *
+ * @STATUS@        draft / approved / published
+ * @APPROVER@      user that approved the draft
+ * @APPROVALDATE@  date of approval
+ * @PUBLISHER@     user that published the page
+ * @PUBLISHDATE@   date of publishing
+ * @VERSION@       shown version 
+ * @LATESTVERSION@ latest published version
+ *
+ * @author  Josquin DEHAENE <josquin@moka.works>
+ * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
+{
+    /**
+     * @var \helper_plugin_structpublish_db 
+     */
+    protected $dbHelper;
+
+    public function register(Doku_Event_Handler $controller)
+    {
+        $controller->register_hook('PLUGIN_DW2PDF_REPLACE', 'BEFORE', $this, 'provide_structpublish_replacements');
+        $controller->register_hook('PLUGIN_DW2PDF_REPLACE', 'AFTER', $this, 'clean_structpublish_replacements');
+    }
+
+    /**
+     * Provide StructPublish values for DW2PDF replacements
+     */
+    public function provide_structpublish_replacements(Doku_Event $event)
+    {
+        global $ID;
+        global $INFO;
+        global $REV;
+
+        $this->dbHelper = plugin_load('helper', 'structpublish_db');
+
+        if (!$this->dbHelper->isPublishable()) {
+            return;
+        }
+
+        // get revisions
+        $newestRevision = new Revision($ID, $INFO['currentrev']);
+        if ($REV) {
+            $shownRevision = new Revision($ID, $REV);
+        } else {
+            $shownRevision = $newestRevision;
+        }
+        $latestpubRevision = $newestRevision->getLatestPublishedRevision();
+        $prevpubRevision = $shownRevision->getLatestPublishedRevision($REV ?:  $INFO['currentrev']);
+        $prevapprovedRevision = $shownRevision->getLatestApprovedRevision($REV ?: $INFO['currentrev']);
+
+        //get redactor
+        $pageMeta = p_get_metadata($ID);
+        $event->data['replace']['@REDACTOR@'] = $pageMeta['last_change']['user'];
+
+        // get last published version
+        if ($latestpubRevision != null) {
+            $event->data['replace']['@LATESTVERSION@'] = $latestpubRevision->getVersion();
+        }else{
+            $event->data['replace']['@LATESTVERSION@'] = $this->getLang("status_na");
+        }
+
+        // get status
+        $event->data['replace']['@STATUS@'] = $this->getLang("status_" . $shownRevision->getStatus());
+
+        // status draft
+        if ($event->data['replace']['@STATUS@'] === $this->getLang("status_draft")) {
+            $event->data['replace']['@VERSION@'] = $this->getLang("status_draft");
+            $event->data['replace']['@APPROVER@'] = $this->getLang("status_na");
+            $event->data['replace']['@APPROVALDATE@'] = $this->getLang("status_na");
+            $event->data['replace']['@PUBLISHER@'] = $this->getLang("status_na");
+            $event->data['replace']['@PUBLISHDATE@'] = $this->getLang("status_na");
+        }
+
+        // status approved
+        if ($event->data['replace']['@STATUS@'] === $this->getLang("status_approved")) {
+            $event->data['replace']['@VERSION@'] = $this->getLang("status_approved");
+            $event->data['replace']['@APPROVER@'] = $shownRevision->getUser();
+            $event->data['replace']['@APPROVALDATE@'] = $shownRevision->getDateTime();
+            $event->data['replace']['@PUBLISHER@'] = $this->getLang("status_na");
+            $event->data['replace']['@PUBLISHDATE@'] = $this->getLang("status_na");
+        }
+
+        // status published
+        if ($event->data['replace']['@STATUS@'] === $this->getLang("status_published")) {
+            $event->data['replace']['@VERSION@'] = $shownRevision->getVersion();
+            $event->data['replace']['@APPROVER@'] = $prevapprovedRevision->getUser();
+            $event->data['replace']['@APPROVALDATE@'] = $prevapprovedRevision->getDateTime();
+            $event->data['replace']['@PUBLISHER@'] = $shownRevision->getUser();
+            $event->data['replace']['@PUBLISHDATE@'] = $shownRevision->getDateTime();
+        }
+
+    }
+
+
+    /**
+     * Clean up replacements in DW2PDF content
+     */
+    public function clean_structpublish_replacements(Doku_Event $event)
+    {
+        $event->data['content'] = str_replace(
+            ['@APPROVER@', '@APPROVALDATE@', '@PUBLISHER@', '@PUBLISHDATE@', '@VERSION@', '@STATUS@', '@REDACTOR@' , '@LATESTVERSION@'],
+            ['', '', '', '', '', '', '', ''],
+            $event->data['content']
+        );
+    }
+}

--- a/action/dw2pdf.php
+++ b/action/dw2pdf.php
@@ -14,7 +14,7 @@ use dokuwiki\plugin\structpublish\meta\Revision;
  * @VERSION@       shown version 
  * @LATESTVERSION@ latest published version
  *
- * @author  Josquin DEHAENE <josquin@moka.works>
+ * @author  Josquin Dehaene <jo@foobarjo.org>
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  */
 
@@ -67,15 +67,18 @@ class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
         $pageMeta = p_get_metadata($ID);
         $event->data['replace']['@REDACTOR@'] = $pageMeta['last_change']['user'];
 
-        // get last published version
+        // get last published version & revision
         if ($latestpubRevision != null) {
             $event->data['replace']['@LATESTVERSION@'] = $latestpubRevision->getVersion();
+            $event->data['replace']['@LATESTVERSIONREVISION@'] = $latestpubRevision->getRev();
         }else{
             $event->data['replace']['@LATESTVERSION@'] = $this->getLang("status_na");
+            $event->data['replace']['@LATESTVERSIONREVISION@'] = $this->getLang("status_na");;
         }
 
-        // get status
+        // get status and revision
         $event->data['replace']['@STATUS@'] = $this->getLang("status_" . $shownRevision->getStatus());
+        $event->data['replace']['@REVISION@'] = $shownRevision->getRev();
 
         // status draft
         if ($event->data['replace']['@STATUS@'] === $this->getLang("status_draft")) {

--- a/action/dw2pdf.php
+++ b/action/dw2pdf.php
@@ -11,8 +11,10 @@ use dokuwiki\plugin\structpublish\meta\Revision;
  * @APPROVALDATE@  date of approval
  * @PUBLISHER@     user that published the page
  * @PUBLISHDATE@   date of publishing
- * @VERSION@       shown version 
- * @LATESTVERSION@ latest published version
+ * @VERSION@       shown version
+ * @REVISION@      shown revision
+ * @LATESTPUBLISHEDVERSION@ latest published version
+ * @LATESTPUBLISHEDREVISION@ latest published revision
  *
  * @author  Josquin Dehaene <jo@foobarjo.org>
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
@@ -21,7 +23,7 @@ use dokuwiki\plugin\structpublish\meta\Revision;
 class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
 {
     /**
-     * @var \helper_plugin_structpublish_db 
+     * @var \helper_plugin_structpublish_db
      */
     protected $dbHelper;
 
@@ -63,17 +65,17 @@ class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
         $prevpubRevision = $shownRevision->getLatestPublishedRevision($REV ?:  $INFO['currentrev']);
         $prevapprovedRevision = $shownRevision->getLatestApprovedRevision($REV ?: $INFO['currentrev']);
 
-        //get redactor
+        // get redactor
         $pageMeta = p_get_metadata($ID);
         $event->data['replace']['@REDACTOR@'] = $pageMeta['last_change']['user'];
 
-        // get last published version & revision
+        // get lastest published version & revision
         if ($latestpubRevision != null) {
-            $event->data['replace']['@LATESTVERSION@'] = $latestpubRevision->getVersion();
-            $event->data['replace']['@LATESTVERSIONREVISION@'] = $latestpubRevision->getRev();
+            $event->data['replace']['@LATESTPUBLISHEDVERSION@'] = $latestpubRevision->getVersion();
+            $event->data['replace']['@LATESTPUBLISHEDREVISION@'] = $latestpubRevision->getRev();
         }else{
-            $event->data['replace']['@LATESTVERSION@'] = $this->getLang("status_na");
-            $event->data['replace']['@LATESTVERSIONREVISION@'] = $this->getLang("status_na");;
+            $event->data['replace']['@LATESTPUBLISHEDVERSION@'] = $this->getLang("status_na");
+            $event->data['replace']['@LATESTPUBLISHEDREVISION@'] = $this->getLang("status_na");;
         }
 
         // get status and revision
@@ -115,8 +117,8 @@ class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
     public function clean_structpublish_replacements(Doku_Event $event)
     {
         $event->data['content'] = str_replace(
-            ['@APPROVER@', '@APPROVALDATE@', '@PUBLISHER@', '@PUBLISHDATE@', '@VERSION@', '@STATUS@', '@REDACTOR@' , '@LATESTVERSION@'],
-            ['', '', '', '', '', '', '', ''],
+            ['@APPROVER@', '@APPROVALDATE@', '@LATESTPUBLISHEDREVISION@', '@REVISION@', '@PUBLISHER@', '@PUBLISHDATE@', '@VERSION@', '@STATUS@', '@REDACTOR@' , '@LATESTPUBLISHEDVERSION@'],
+            ['', '', '', '', '', '', '', '', '', ''],
             $event->data['content']
         );
     }

--- a/action/dw2pdf.php
+++ b/action/dw2pdf.php
@@ -40,6 +40,12 @@ class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
         global $INFO;
         global $REV;
 
+        //force reload of the globals. usefull when coming from bookcreator
+        $keep = $ID;
+        $ID = $event->data['id']; 
+        $INFO = pageinfo();
+        $REV = null;
+
         $this->dbHelper = plugin_load('helper', 'structpublish_db');
 
         if (!$this->dbHelper->isPublishable()) {
@@ -97,9 +103,8 @@ class action_plugin_structpublish_dw2pdf extends DokuWiki_Action_Plugin
             $event->data['replace']['@PUBLISHER@'] = $shownRevision->getUser();
             $event->data['replace']['@PUBLISHDATE@'] = $shownRevision->getDateTime();
         }
-
+        $ID = $keep;
     }
-
 
     /**
      * Clean up replacements in DW2PDF content

--- a/action/save.php
+++ b/action/save.php
@@ -10,7 +10,9 @@ use dokuwiki\plugin\structpublish\meta\Revision;
  */
 class action_plugin_structpublish_save extends DokuWiki_Action_Plugin
 {
-    /** @inheritDoc */
+    /**
+     * @inheritDoc 
+     */
     public function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('COMMON_WIKIPAGE_SAVE', 'AFTER', $this, 'handleSave');
@@ -19,12 +21,14 @@ class action_plugin_structpublish_save extends DokuWiki_Action_Plugin
     /**
      * Handle the page save event to store revision meta data
      *
-     * @param Doku_Event $event
+     * @param  Doku_Event $event
      * @return void
      */
     public function handleSave(Doku_Event $event)
     {
-        /** @var helper_plugin_structpublish_db $dbHelper */
+        /**
+ * @var helper_plugin_structpublish_db $dbHelper 
+*/
         $dbHelper = plugin_load('helper', 'structpublish_db');
 
         $id = $event->data['id'];
@@ -38,6 +42,8 @@ class action_plugin_structpublish_save extends DokuWiki_Action_Plugin
 
         $revision = new Revision($id, $event->data['newRevision']);
         $revision->setStatus(Constants::STATUS_DRAFT);
+        $revision->setUser($_SERVER['REMOTE_USER']);
+        $revision->setTimestamp(time());
 
         try {
             $revision->save();

--- a/action/show.php
+++ b/action/show.php
@@ -5,10 +5,14 @@ use dokuwiki\plugin\structpublish\meta\Revision;
 
 class action_plugin_structpublish_show extends DokuWiki_Action_Plugin
 {
-    /** @var int */
+    /**
+     * @var int 
+     */
     protected static $latestPublishedRev;
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc 
+     */
     public function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'handleShow');
@@ -18,7 +22,7 @@ class action_plugin_structpublish_show extends DokuWiki_Action_Plugin
     /**
      * Decide which revision to show based on role assignments
      *
-     * @param Doku_Event $event
+     * @param  Doku_Event $event
      * @return void
      */
     public function handleShow(Doku_Event $event)
@@ -31,12 +35,13 @@ class action_plugin_structpublish_show extends DokuWiki_Action_Plugin
         global $REV;
         global $INFO;
 
-        /** @var helper_plugin_structpublish_db $dbHelper */
+        /**
+ * @var helper_plugin_structpublish_db $dbHelper 
+*/
         $dbHelper = plugin_load('helper', 'structpublish_db');
 
-        if (
-            !$dbHelper->isPublishable() ||
-            (auth_isadmin() && !$this->getConf('restrict_admin'))
+        if (!$dbHelper->isPublishable() 
+            || (auth_isadmin() && !$this->getConf('restrict_admin'))
         ) {
             return;
         }
@@ -44,7 +49,8 @@ class action_plugin_structpublish_show extends DokuWiki_Action_Plugin
         $currentRevision = new Revision($ID, $REV ?: $INFO['currentrev']);
         $isPublished = $currentRevision->getStatus() === Constants::STATUS_PUBLISHED;
 
-        if (!$dbHelper->isPublisher($ID)) {
+        //Show published version or nothing to user with no Role and no ACL write
+        if (!$dbHelper->isPublisher($ID) && auth_quickaclcheck($ID) < 2) {
             $latestPublished = $currentRevision->getLatestPublishedRevision();
             // there is no published revision, show nothing
             if (!$isPublished && is_null($latestPublished)) {
@@ -67,17 +73,18 @@ class action_plugin_structpublish_show extends DokuWiki_Action_Plugin
      * Suppress message about viewing an old revision if it is the latest one
      * that the current user is allowed to see.
      *
-     * @param Doku_Event $event
+     * @param  Doku_Event $event
      * @return void
      */
     public function handleShowrev(Doku_Event $event)
     {
-        /** @var helper_plugin_structpublish_db $dbHelper */
+        /**
+ * @var helper_plugin_structpublish_db $dbHelper 
+*/
         $dbHelper = plugin_load('helper', 'structpublish_db');
 
-        if (
-            !$dbHelper->isPublishable() ||
-            (auth_isadmin() && !$this->getConf('restrict_admin'))
+        if (!$dbHelper->isPublishable() 
+            || (auth_isadmin() && !$this->getConf('restrict_admin'))
         ) {
             return;
         }

--- a/conf/default.php
+++ b/conf/default.php
@@ -10,3 +10,4 @@ $conf['restrict_admin'] = 1;
 $conf['email_enable'] = 0;
 $conf['email_status'] = '';
 $conf['compact_view'] = 0;
+$conf['publish_needs_approve'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -10,3 +10,4 @@ $meta['restrict_admin'] = ['onoff'];
 $meta['email_enable'] = ['onoff'];
 $meta['email_status'] = ['multicheckbox', '_other' => 'never', '_choices' => ['approve', 'publish']];
 $meta['compact_view'] = ['onoff'];
+$meta['publish_needs_approve'] = ['onoff'];

--- a/helper/db.php
+++ b/helper/db.php
@@ -15,7 +15,9 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
      */
     public function getDB()
     {
-        /** @var helper_plugin_struct_db $struct */
+        /**
+ * @var helper_plugin_struct_db $struct 
+*/
         $struct = plugin_load('helper', 'struct_db');
         if (!$struct) {
             // FIXME show message?
@@ -26,9 +28,8 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
             return null;
         }
 
-        // on init
+        // we need to access the strucpublish even if user has no role
         if (!$this->initialized) {
-            $sqlite->getPdo()->sqliteCreateFunction('IS_PUBLISHER', [$this, 'isPublisher'], -1);
             $this->initialized = true;
         }
 
@@ -77,8 +78,8 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
     /**
      * Check if the current user has the given roles on the current page
      *
-     * @param string $pid The page ID to check access for
-     * @param string[] $roles Roles needed. Empty for any role
+     * @param  string   $pid   The page ID to check access for
+     * @param  string[] $roles Roles needed. Empty for any role
      * @return bool
      */
     public function checkAccess($pid, $roles = [])
@@ -91,7 +92,7 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
      *
      * Params are read via function args
      *
-     * @param ...string $pid, $userId, $groups...
+     * @param  ...string $pid, $userId, $groups...
      * @return int Return an integer instead of boolean for better sqlite compatibility
      */
     public function isPublisher()
@@ -120,10 +121,10 @@ class helper_plugin_structpublish_db extends DokuWiki_Plugin
     /**
      * Check if a given user has role assignment for a given page
      *
-     * @param string $pid Page to check
-     * @param string $userId User login name, current user if empty
-     * @param string[] $grps Groups the user has, current user's groups if empty user
-     * @param string[] $roles Roles the user should have, empty for any role
+     * @param  string   $pid    Page to check
+     * @param  string   $userId User login name, current user if empty
+     * @param  string[] $grps   Groups the user has, current user's groups if empty user
+     * @param  string[] $roles  Roles the user should have, empty for any role
      * @return bool
      */
     public static function userHasRole($pid, $userId = '', $grps = [], $roles = [])

--- a/helper/publish.php
+++ b/helper/publish.php
@@ -12,7 +12,9 @@ use dokuwiki\plugin\structpublish\meta\Revision;
  */
 class helper_plugin_structpublish_publish extends DokuWiki_Plugin
 {
-    /** @var helper_plugin_structpublish_db  */
+    /**
+     * @var helper_plugin_structpublish_db  
+     */
     protected $dbHelper;
 
     public function __construct()
@@ -23,7 +25,7 @@ class helper_plugin_structpublish_publish extends DokuWiki_Plugin
     /**
      * Save publish data
      *
-     * @param string $action
+     * @param  string $action
      * @return Revision
      * @throws Exception
      */
@@ -37,6 +39,15 @@ class helper_plugin_structpublish_publish extends DokuWiki_Plugin
         }
 
         $revision = new Revision($ID, $INFO['currentrev']);
+
+        //do nothing if action is approve and the current revison have already been approved 
+        if ($action === Constants::ACTION_APPROVE && $revision->getLatestApprovedRevision() !== null && $revision->getRev() == $revision->getLatestApprovedRevision()->getRev()) {
+            return $revision;
+        }
+        //do nothing if action is publish and the current revison have already been published 
+        if ($action === Constants::ACTION_PUBLISH && $revision->getLatestPublishedRevision() !== null && $revision->getRev() == $revision->getLatestPublishedRevision()->getRev()) {
+            return $revision;
+        }
 
         if ($action === Constants::ACTION_PUBLISH) {
             $revision->setVersion($newversion);

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -41,3 +41,6 @@ $lang['assign_status'] = 'Aktion';
 $lang['assign_add'] = 'Hinzufügen';
 $lang['assign_del'] = 'Löschen';
 
+// email
+$lang['email_subject'] = 'Veröffentlichungsstatus einer Wikiseite hat sich geändert';
+$lang['email_error_norecipients'] = 'Keine Empfänger zum Benachrichtigen gefunden!';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -16,6 +16,7 @@ $lang['actions'] = 'Aktionen';
 $lang['status_draft'] = 'Entwurf';
 $lang['status_approved'] = 'Zur Freigabe bereit';
 $lang['status_published'] = 'Freigegeben';
+$lang['status_na'] = 'k.A.';
 $lang['action_approve'] = 'Zur Freigabe bereitstellen';
 $lang['action_publish'] = 'Freigeben';
 

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Regeln gelten auch für Superusers. Wenn deaktiviert,
 $lang['email_enable'] = 'E-Mails aktivieren';
 $lang['email_status'] = 'Bei welchen Statusänderungen sollen E-Mails versendet werden?';
 $lang['compact_view'] = 'Kompakter Banner';
+$lang['publish_needs_approve'] = 'Seiten müssen vor ihrer Veröffentlichung genehmigt werden';
+

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -16,6 +16,7 @@ $lang['actions'] = 'Actions';
 $lang['status_draft'] = 'Draft';
 $lang['status_approved'] = 'Approved';
 $lang['status_published'] = 'Published';
+$lang['status_na'] = 'N/A';
 $lang['action_approve'] = 'Approve';
 $lang['action_publish'] = 'Publish';
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Publishing rules apply to superusers too. Uncheck if 
 $lang['email_enable'] = 'Send emails';
 $lang['email_status'] = 'Status changes that trigger emails';
 $lang['compact_view'] = 'Compact banner';
+$lang['publish_needs_approve'] = 'Pages must be approved before being published';
+

--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Archivo de idioma en español para el plugin structpublish
+ */
+
+// entrada del menú para plugins de administración
+$lang['menu'] = 'Datos estructurados de publicación';
+
+// banner
+$lang['version'] = 'Versión';
+$lang['newversion'] = 'Nueva versión';
+$lang['status'] = 'Estado de publicación de la página que está viendo actualmente';
+$lang['actions'] = 'Acciones';
+$lang['status_draft'] = 'Borrador';
+$lang['status_approved'] = 'Aprobado';
+$lang['status_published'] = 'Publicado';
+$lang['status_na'] = 'N/D';
+$lang['action_approve'] = 'Aprobar';
+$lang['action_publish'] = 'Publicar';
+
+$lang['diff'] = 'Mostrar diferencias';
+$lang['banner_status_draft'] = 'Esta revisión de la página es un <strong>borrador en progreso</strong>, creado el {revision}.';
+$lang['banner_status_approved'] = 'Esta revisión de la página ha sido <strong>aprobada para su publicación</strong> el {datetime} por {user}.';
+$lang['banner_status_published'] = 'Esta revisión de la página ha sido <strong>publicada <span class="plugin-structpublish-version">como versión "{version}"</span></strong> el {datetime} por {user}.';
+$lang['banner_latest_publish'] = 'La página fue publicada más recientemente como versión {version} por {user} el {datetime}.';
+$lang['banner_previous_publish'] = 'La página fue publicada anteriormente como versión {version} por {user} el {datetime}.';
+$lang['banner_latest_draft'] = 'Existe un borrador más reciente creado el {revision}.';
+$lang['compact_banner_status_draft'] = 'Borrador';
+$lang['compact_banner_status_approved'] = 'Aprobado';
+$lang['compact_banner_status_published'] = 'Publicado como versión "{version}" el {datetime} por {user}';
+$lang['compact_banner_latest_publish'] = '';
+$lang['compact_banner_previous_publish'] = '';
+$lang['compact_banner_latest_draft'] = 'Borrador más reciente: {revision}';
+
+// administración
+$lang['assign_pattern'] = 'Patrón';
+$lang['assign_user'] = 'Usuario o @grupo';
+$lang['assign_status'] = 'Estado';
+$lang['assign_add'] = 'Añadir asignación';
+$lang['assign_del'] = 'Eliminar asignación';
+
+// correo electrónico
+$lang['email_subject'] = 'El estado de publicación de una página wiki ha cambiado';
+$lang['email_error_norecipients'] = '¡No se encontraron destinatarios para notificar!';

--- a/lang/es/mail.txt
+++ b/lang/es/mail.txt
@@ -1,0 +1,6 @@
+Hola,
+
+Te informamos que el estado de la página “@PAGE@” ha cambiado a @STATUS_CURRENT@.
+
+Puedes tomar medidas aquí: @URL@
+

--- a/lang/es/settings.php
+++ b/lang/es/settings.php
@@ -1,0 +1,7 @@
+<?php
+
+$lang['restrict_admin'] = 'Las reglas de publicación también se aplican a los superusuarios. Desmarca esta opción si los administradores deben ver las revisiones no publicadas aunque no sean editores.';
+$lang['email_enable'] = 'Enviar correos electrónicos';
+$lang['email_status'] = 'Cambios de estado que activan correos electrónicos';
+$lang['compact_view'] = 'Banner compacto';
+$lang['publish_needs_approve'] = 'Las páginas deben ser aprobadas antes de ser publicadas';

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * french language file for structpublish plugin
+ */
+
+// entrée du menu pour les plugins d'administration
+$lang['menu'] = 'Données de publication structurées';
+
+// banner
+$lang['version'] = 'Version';
+$lang['newversion'] = 'Nouvelle version';
+$lang['status'] = 'Statut de publication de la page que vous consultez actuellement';
+$lang['actions'] = 'Actions';
+$lang['status_draft'] = 'Brouillon';
+$lang['status_approved'] = 'Approuvé';
+$lang['status_published'] = 'Publié';
+$lang['status_na'] = 'N/A';
+$lang['action_approve'] = 'Approuver';
+$lang['action_publish'] = 'Publier';
+
+$lang['diff'] = 'Afficher les différences';
+$lang['banner_status_draft'] = 'Cette révision de la page est un <strong>brouillon en cours</strong>, créé le {revision}.';
+$lang['banner_status_approved'] = 'Cette révision de la page a été <strong>approuvée pour publication</strong> le {datetime} par {user}.';
+$lang['banner_status_published'] = 'Cette révision de la page a été <strong>publiée <span class="plugin-structpublish-version">en tant que version "{version}"</span></strong> le {datetime} par {user}.';
+$lang['banner_latest_publish'] = 'La page a été publiée pour la dernière fois en tant que version {version} par {user} le {datetime}.';
+$lang['banner_previous_publish'] = 'La page a été précédemment publiée en tant que version {version} par {user} le {datetime}.';
+$lang['banner_latest_draft'] = 'Un brouillon plus récent a été créé le {revision}.';
+$lang['compact_banner_status_draft'] = 'Brouillon';
+$lang['compact_banner_status_approved'] = 'Approuvé';
+$lang['compact_banner_status_published'] = 'Publié en tant que version "{version}" le {datetime} par {user}';
+$lang['compact_banner_latest_publish'] = '';
+$lang['compact_banner_previous_publish'] = '';
+$lang['compact_banner_latest_draft'] = 'Brouillon plus récent : {revision}';
+
+// admin
+$lang['assign_pattern'] = 'Modèle';
+$lang['assign_user'] = 'Utilisateur ou @group';
+$lang['assign_status'] = 'Statut';
+$lang['assign_add'] = 'Ajouter une attribution';
+$lang['assign_del'] = 'Supprimer une attribution';
+
+// email
+$lang['email_subject'] = 'Le statut de publication d’une page wiki a changé';
+$lang['email_error_norecipients'] = 'Aucun destinataire trouvé pour la notification !';
+

--- a/lang/fr/mail.txt
+++ b/lang/fr/mail.txt
@@ -1,0 +1,5 @@
+Bonjour,
+
+Ceci est une notification pour vous informer que le statut de la page « @PAGE@ » a changé pour @STATUS_CURRENT@.
+
+Vous pouvez agir dessus ici : @URL@

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -1,0 +1,8 @@
+<?php
+
+$lang['restrict_admin'] = 'Les règles de publication s’appliquent également aux super-utilisateurs. Décochez cette option si les administrateurs doivent voir les révisions non publiées même s’ils ne sont pas éditeurs.';
+$lang['email_enable'] = 'Envoyer des e-mails';
+$lang['email_status'] = 'Changements de statut déclenchant l’envoi d’e-mails';
+$lang['compact_view'] = 'Bannière compacte';
+$lang['publish_needs_approve'] = 'Les pages doivent être approuvées avant d’être publiées';
+

--- a/lang/it/lang.php
+++ b/lang/it/lang.php
@@ -16,6 +16,7 @@ $lang['actions'] = 'Azioni';
 $lang['status_draft'] = 'Bozza';
 $lang['status_approved'] = 'Approvata';
 $lang['status_published'] = 'Pubblicata';
+$lang['status_na'] = 'N/D';
 $lang['action_approve'] = 'Approva';
 $lang['action_publish'] = 'Pubblica';
 

--- a/lang/it/settings.php
+++ b/lang/it/settings.php
@@ -4,3 +4,5 @@ $lang['restrict_admin'] = 'Le regole di pubblicazione vengono applicate anche ag
 $lang['email_enable'] = 'Invia e-mail';
 $lang['email_status'] = 'Modifiche dello stato che attivano le notifiche via e-mail';
 $lang['compact_view'] = 'Banner compatto';
+$lang['publish_needs_approve'] = 'Le pagine devono essere approvate prima di essere pubblicate';
+

--- a/meta/Revision.php
+++ b/meta/Revision.php
@@ -13,7 +13,9 @@ use dokuwiki\plugin\struct\meta\Value;
  */
 class Revision
 {
-    /** @var SQLiteDB */
+    /**
+     * @var SQLiteDB 
+     */
     protected $sqlite;
 
     protected $schema;
@@ -25,7 +27,9 @@ class Revision
     protected $version;
     protected $user;
     protected $datetime;
-    /** @var bool|\dokuwiki\plugin\struct\meta\Column */
+    /**
+     * @var bool|\dokuwiki\plugin\struct\meta\Column 
+     */
     protected $statusCol;
     protected $versionCol;
     protected $userCol;
@@ -35,8 +39,8 @@ class Revision
     /**
      * Constructor
      *
-     * @param string $id page id
-     * @param int $rev revision
+     * @param string $id  page id
+     * @param int    $rev revision
      */
     public function __construct($id, $rev)
     {
@@ -52,7 +56,9 @@ class Revision
         $this->datetimeCol = $this->schema->findColumn('datetime');
         $this->revisionCol = $this->schema->findColumn('revision');
 
-        /** @var Value[] $values */
+        /**
+ * @var Value[] $values 
+*/
         $values = $this->getCoreData(['revision=' . $this->rev]);
 
         if (!empty($values)) {
@@ -210,7 +216,7 @@ class Revision
      * Update publish status in the core table
      *
      * @param string $pid
-     * @param int $rid
+     * @param int    $rid
      */
     protected function updateCoreData($pid, $rid = 0)
     {
@@ -234,7 +240,7 @@ class Revision
      *
      * @see https://www.dokuwiki.org/plugin:struct:filters
      *
-     * @param array $andFilters
+     * @param  array $andFilters
      * @return array|Value[]
      */
     public function getCoreData($andFilters = [])
@@ -268,7 +274,7 @@ class Revision
      * Return "latest" published revision of a given page.
      * If $rev is specified, "latest" means relative to the $rev revision.
      *
-     * @param int|null $rev
+     * @param  int|null $rev
      * @return Revision|null
      */
     public function getLatestPublishedRevision($rev = null)
@@ -294,5 +300,37 @@ class Revision
         $published->setVersion($latestPublished[$this->versionCol->getColref() - 1]->getRawValue());
 
         return $published;
+    }
+
+    /**
+     * Return "latest" approved revision of a given page.
+     * If $rev is specified, "latest" means relative to the $rev revision.
+     *
+     * @param  int|null $rev
+     * @return Revision|null
+     */
+    public function getLatestApprovedRevision($rev = null)
+    {
+        $andFilters[] = 'status=' . Constants::STATUS_APPROVED;
+        if ($rev) {
+            $andFilters[] .= 'revision=' . $rev;
+        }
+        $latestApproved = $this->getCoreData($andFilters);
+
+        if (empty($latestApproved)) {
+            return null;
+        }
+
+        $approved = new Revision(
+            $this->id,
+            $latestApproved[$this->revisionCol->getColref() - 1]->getRawValue()
+        );
+
+        $approved->setStatus($latestApproved[$this->statusCol->getColref() - 1]->getRawValue());
+        $approved->setUser($latestApproved[$this->userCol->getColref() - 1]->getRawValue());
+        $approved->setDatetime($latestApproved[$this->datetimeCol->getColref() - 1]->getRawValue());
+        $approved->setVersion($latestApproved[$this->versionCol->getColref() - 1]->getRawValue());
+
+        return $approved;
     }
 }

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   structpublish
 author Anna Dabrowska
 email  dokuwiki@cosmocode.de
-date   2024-05-20
+date   2025-03-13
 name   structpublish plugin
 desc   Publishing workflows based on struct
 url    https://dokuwiki.org/plugin:structpublish


### PR DESCRIPTION
This PR introduces a new configuration option, `publish_needs_approve`, that enforces approval before a page can be published. When this option is enabled, the "Publish" button will only be available if the page has been approved.